### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ soyprice
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/limiear/soyprice?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-[![License](https://pypip.in/license/soyprice/badge.svg)](https://pypi.python.org/pypi/soyprice/) [![Downloads](https://pypip.in/download/soyprice/badge.svg)](https://pypi.python.org/pypi/soyprice/) [![Build Status](https://travis-ci.org/limiear/soyprice.svg?branch=master)](https://travis-ci.org/limiear/soyprice) [![Coverage Status](https://coveralls.io/repos/limiear/soyprice/badge.png)](https://coveralls.io/r/limiear/soyprice) [![Code Health](https://landscape.io/github/limiear/soyprice/master/landscape.png)](https://landscape.io/github/limiear/soyprice/master) [![PyPI version](https://badge.fury.io/py/soyprice.svg)](http://badge.fury.io/py/soyprice)
-[![Supported Python versions](https://pypip.in/py_versions/soyprice/badge.svg)](https://pypi.python.org/pypi/soyprice/) [![Stories in Ready](https://badge.waffle.io/limiear/soyprice.png?label=ready&title=Ready)](https://waffle.io/limiear/soyprice)
+[![License](https://img.shields.io/pypi/l/soyprice.svg)](https://pypi.python.org/pypi/soyprice/) [![Downloads](https://img.shields.io/pypi/dm/soyprice.svg)](https://pypi.python.org/pypi/soyprice/) [![Build Status](https://travis-ci.org/limiear/soyprice.svg?branch=master)](https://travis-ci.org/limiear/soyprice) [![Coverage Status](https://coveralls.io/repos/limiear/soyprice/badge.png)](https://coveralls.io/r/limiear/soyprice) [![Code Health](https://landscape.io/github/limiear/soyprice/master/landscape.png)](https://landscape.io/github/limiear/soyprice/master) [![PyPI version](https://badge.fury.io/py/soyprice.svg)](http://badge.fury.io/py/soyprice)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/soyprice.svg)](https://pypi.python.org/pypi/soyprice/) [![Stories in Ready](https://badge.waffle.io/limiear/soyprice.png?label=ready&title=Ready)](https://waffle.io/limiear/soyprice)
 
 A python script to estimate the soy price in and show it in the twitter timeline.
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20soyprice))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `soyprice`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.